### PR TITLE
Address issues with user.name and user.id mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Run `npm install hubot-keys`
 
 ```
 hubot my public key is <public_ssh_key> - Stores the user's public SSH key.
-hubot what is my public key - Returns the user's public SSH key.
+hubot what is (my|<username>) public key - Returns the user's public SSH key.
 hubot (delete|remove|forget) my public key - Removes the user's public SSH key.
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,80 @@
 {
-  "name": "hubot-keys",
+  "_args": [
+    [
+      {
+        "raw": "hubot-keys@^2.1.2",
+        "scope": null,
+        "escapedName": "hubot-keys",
+        "name": "hubot-keys",
+        "rawSpec": "^2.1.2",
+        "spec": ">=2.1.2 <3.0.0",
+        "type": "range"
+      },
+      "/home/ubuntu/winston"
+    ]
+  ],
+  "_from": "hubot-keys@>=2.1.2 <3.0.0",
+  "_id": "hubot-keys@2.1.2",
+  "_inCache": true,
+  "_location": "/hubot-keys",
+  "_nodeVersion": "4.4.1",
+  "_npmOperationalInternal": {
+    "host": "packages-16-east.internal.npmjs.com",
+    "tmp": "tmp/hubot-keys-2.1.2.tgz_1463415282570_0.15274260425940156"
+  },
+  "_npmUser": {
+    "name": "contolini",
+    "email": "chris@contolini.com"
+  },
+  "_npmVersion": "3.8.5",
+  "_phantomChildren": {},
+  "_requested": {
+    "raw": "hubot-keys@^2.1.2",
+    "scope": null,
+    "escapedName": "hubot-keys",
+    "name": "hubot-keys",
+    "rawSpec": "^2.1.2",
+    "spec": ">=2.1.2 <3.0.0",
+    "type": "range"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/hubot-keys/-/hubot-keys-2.1.2.tgz",
+  "_shasum": "71af44a9f82039ec3d76df30749015052c10c86c",
+  "_shrinkwrap": null,
+  "_spec": "hubot-keys@^2.1.2",
+  "_where": "/home/ubuntu/winston",
+  "author": {
+    "name": "Chris Contolini",
+    "email": "contolini@users.noreply.github.com"
+  },
+  "bugs": {
+    "url": "https://github.com/catops/hubot-keys/issues"
+  },
+  "dependencies": {
+    "coffee-script": "~1.6",
+    "grunt": "^1.0.1"
+  },
   "description": "Store users' public keys in Hubot",
-  "version": "2.0.1",
-  "author": "Chris Contolini <contolini@users.noreply.github.com>",
-  "license": "MIT",
+  "devDependencies": {
+    "chai": "*",
+    "grunt-contrib-watch": "~0.5.3",
+    "grunt-mocha-test": "~0.7.0",
+    "grunt-release": "~0.6.0",
+    "matchdep": "~0.1.2",
+    "mocha": "*",
+    "sinon": "*",
+    "sinon-chai": "*"
+  },
+  "directories": {},
+  "dist": {
+    "shasum": "71af44a9f82039ec3d76df30749015052c10c86c",
+    "tarball": "https://registry.npmjs.org/hubot-keys/-/hubot-keys-2.1.2.tgz"
+  },
+  "gitHead": "c54cb818835f79123415c81be345281fac8419e2",
+  "homepage": "https://github.com/catops/hubot-keys#readme",
   "keywords": [
     "hubot",
     "hubot-scripts",
@@ -11,29 +82,23 @@
     "ssh",
     "keys"
   ],
+  "license": "MIT",
+  "main": "index.coffee",
+  "maintainers": [
+    {
+      "name": "contolini",
+      "email": "chris@contolini.com"
+    }
+  ],
+  "name": "hubot-keys",
+  "optionalDependencies": {},
+  "readme": "ERROR: No README data found!",
   "repository": {
     "type": "git",
     "url": "git://github.com/catops/hubot-keys.git"
   },
-  "bugs": {
-    "url": "https://github.com/catops/hubot-keys/issues"
-  },
-  "dependencies": {
-    "coffee-script": "~1.10.0",
-    "grunt": "^1.0.1"
-  },
-  "devDependencies": {
-    "mocha": "*",
-    "chai": "*",
-    "sinon-chai": "*",
-    "sinon": "*",
-    "grunt-mocha-test": "~0.12.7",
-    "grunt-release": "~0.13.1",
-    "matchdep": "~1.0.1",
-    "grunt-contrib-watch": "~1.0.0"
-  },
-  "main": "index.coffee",
   "scripts": {
     "test": "grunt test"
-  }
+  },
+  "version": "2.1.2"
 }

--- a/src/hubot-keys.coffee
+++ b/src/hubot-keys.coffee
@@ -3,7 +3,7 @@
 #
 # Commands:
 #   hubot my public key is <public_ssh_key> - Stores the user's public SSH key.
-#   hubot what is my public key - Returns the user's public SSH key.
+#   hubot what is (my|<username>) public key - Returns the user's public SSH key.
 #   hubot (delete|remove|forget) my public key - Removes the user's public SSH key.
 #
 # Notes:
@@ -51,14 +51,19 @@ module.exports = (robot) ->
     key = res.match[2]
     if !/ssh-rsa AAAA[0-9A-Za-z+\/]+[=]{0,3}( [^@]+@[^@]+)?/.test(key)
       return res.send "`#{key}` is not a valid public SSH key. You can find your key with `cat ~/.ssh/id_rsa.pub`."
-    robot.keys.addKeyForUserId res.envelope.user.id, key
+    robot.keys.addKeyForUserName res.envelope.user.name, key
     res.send "Okay, I stored your public SSH key as #{key.substring(0, 40)}..."
 
-  robot.respond /(what is |show )?my public (ssh )?key$/i, (res) ->
-    key = robot.keys.keyForUserId res.envelope.user.id
+  robot.respond /(what is |show )?([^\s]+)('s?)? public (ssh )?key$/i, (res) ->
+    user = res.match[2]
+    console.log user
+    if user == 'my'
+      user = res.envelope.user.name
+    key = robot.keys.keyForUserName user
     if !key
-      return res.send "I don't know your public SSH key. Add it with `#{robot.name} my public key is <key>`. You can find your key with `cat ~/.ssh/id_rsa.pub`."
-    res.send "Your public ssh key is #{key}"
+      return res.send "I don't know #{user}'s public SSH key. Add it with `#{robot.name} my public key is <key>`. You can find your key with `cat ~/.ssh/id_rsa.pub`."
+    message = "```\n# #{robot.brain.userForName(user).email_address}\n#{key}\n```"
+    res.send message
 
   robot.respond /(delete|remove|forget) my public (ssh )?key$/i, (res) ->
     key = robot.keys.keyForUserId res.envelope.user.id

--- a/src/hubot-keys.coffee
+++ b/src/hubot-keys.coffee
@@ -18,10 +18,7 @@ module.exports = (robot) ->
   class Keys
 
     keyForUserName: (name) ->
-      console.log name
       user = robot.brain.userForName name
-      console.log "_________________" 
-      console.log user
       user.key
 
     keyForUserId: (id) ->
@@ -35,7 +32,6 @@ module.exports = (robot) ->
 
     addKeyForUserId: (id, key) ->
       user = robot.brain.userForId id
-      console.log user
       user.key = key
       user.key
 
@@ -55,18 +51,14 @@ module.exports = (robot) ->
     key = res.match[2]
     if !/ssh-rsa AAAA[0-9A-Za-z+\/]+[=]{0,3}( [^@]+@[^@]+)?/.test(key)
       return res.send "`#{key}` is not a valid public SSH key. You can find your key with `cat ~/.ssh/id_rsa.pub`."
-    console.log res.envelope.user
     robot.keys.addKeyForUserId res.envelope.user.id, key
     res.send "Okay, I stored your public SSH key as #{key.substring(0, 40)}..."
 
   robot.respond /(what is |show )?([^\s]+)('s?)? public (ssh )?key$/i, (res) ->
     user = res.match[2]
-    console.log res
     if user == 'my'
       # Return the username
-      console.log "in_here"
       user = res.envelope.user.name
-    console.log robot.keys
     key = robot.keys.keyForUserName user
     if !key
       return res.send "I don't know #{user}'s public SSH key. Add it with `#{robot.name} my public key is <key>`. You can find your key with `cat ~/.ssh/id_rsa.pub`."

--- a/src/hubot-keys.coffee
+++ b/src/hubot-keys.coffee
@@ -18,7 +18,10 @@ module.exports = (robot) ->
   class Keys
 
     keyForUserName: (name) ->
+      console.log name
       user = robot.brain.userForName name
+      console.log "_________________" 
+      console.log user
       user.key
 
     keyForUserId: (id) ->
@@ -32,6 +35,7 @@ module.exports = (robot) ->
 
     addKeyForUserId: (id, key) ->
       user = robot.brain.userForId id
+      console.log user
       user.key = key
       user.key
 
@@ -51,14 +55,18 @@ module.exports = (robot) ->
     key = res.match[2]
     if !/ssh-rsa AAAA[0-9A-Za-z+\/]+[=]{0,3}( [^@]+@[^@]+)?/.test(key)
       return res.send "`#{key}` is not a valid public SSH key. You can find your key with `cat ~/.ssh/id_rsa.pub`."
-    robot.keys.addKeyForUserName res.envelope.user.name, key
+    console.log res.envelope.user
+    robot.keys.addKeyForUserId res.envelope.user.id, key
     res.send "Okay, I stored your public SSH key as #{key.substring(0, 40)}..."
 
   robot.respond /(what is |show )?([^\s]+)('s?)? public (ssh )?key$/i, (res) ->
     user = res.match[2]
-    console.log user
+    console.log res
     if user == 'my'
+      # Return the username
+      console.log "in_here"
       user = res.envelope.user.name
+    console.log robot.keys
     key = robot.keys.keyForUserName user
     if !key
       return res.send "I don't know #{user}'s public SSH key. Add it with `#{robot.name} my public key is <key>`. You can find your key with `cat ~/.ssh/id_rsa.pub`."

--- a/test/hubot-keys-test.coffee
+++ b/test/hubot-keys-test.coffee
@@ -18,7 +18,7 @@ describe 'hubot-keys', ->
     expect(@robot.respond).to.have.been.calledWith(/my public (ssh )?key is (.*)/i)
 
   it 'registers a respond listener for retrieving key', ->
-    expect(@robot.respond).to.have.been.calledWith(/(what is |show )?my public (ssh )?key$/i)
+    expect(@robot.respond).to.have.been.calledWith(/(what is |show )?([^\s]+)('s?)? public (ssh )?key$/i)
 
   it 'registers a respond listener deleting key', ->
     expect(@robot.respond).to.have.been.calledWith(/(delete|remove|forget) my public (ssh )?key$/i)


### PR DESCRIPTION
* Fixes the mismatch between user.id and user.name, so that when you call 'hubot what is my public key', it returns the name, and not the ID. This was documented in issue #9 